### PR TITLE
Use build_src_filter, force STSTM32@~12.1, format platformio.ini

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -13,29 +13,25 @@ src_dir      = MMU2
 boards_dir   = buildroot/share/PlatformIO/boards
 default_envs = MMU2_F030C8
 
-
 [common]
 default_src_filter = +<src/*>
-extra_scripts = pre:buildroot/share/PlatformIO/scripts/common-cxxflags.py
-lib_deps = TMCStepper@>=0.6.2,<1.0.0
-build_flags = -fmax-errors=5
-
-
+extra_scripts      = pre:buildroot/share/PlatformIO/scripts/common-cxxflags.py
+lib_deps           = TMCStepper@>=0.6.2,<1.0.0
+build_flags        = -fmax-errors=5
 
 [env:MMU2_F030C8]
-platform  = ststm32
-extends   = common
-board     = MMU2_F030C8
-framework = arduino
+platform          = ststm32@~12.1
+extends           = common
+board             = MMU2_F030C8
+framework         = arduino
 platform_packages = framework-arduinoststm32@>=4.10700,<4.10800
-build_flags   = ${common.build_flags}
-                -IMMU2/src/HAL -std=gnu++14
-src_filter    = ${common.default_src_filter}
-extra_scripts = ${common.extra_scripts}
-                buildroot/share/PlatformIO/scripts/generic_create_variant.py
-                buildroot/share/PlatformIO/scripts/MMU2_F030C8.py
-lib_deps      = ${common.lib_deps}
-lib_ignore    = SoftwareSerial
-
-upload_protocol = jlink
-debug_tool = jlink
+build_flags       = ${common.build_flags}
+                    -IMMU2/src/HAL -std=gnu++14
+build_src_filter  = ${common.default_src_filter}
+extra_scripts     = ${common.extra_scripts}
+                    buildroot/share/PlatformIO/scripts/generic_create_variant.py
+                    buildroot/share/PlatformIO/scripts/MMU2_F030C8.py
+lib_deps          = ${common.lib_deps}
+lib_ignore        = SoftwareSerial
+upload_protocol   = jlink
+debug_tool        = jlink


### PR DESCRIPTION
### Description

Fix/format `platformio.ini` so the project builds:
- `src_filter` will be deprecated in the next PIO release, so use `build_src_filter` instead.
- Lock ststm32 to 12.1 (from https://github.com/bigtreetech/MMU2-DIP/issues/14#issuecomment-1079576521)
- General formatting