### PR TITLE
Fix hard coded chopper timing & R_SENSE override, fix compile warnings

### DIFF
--- a/firmware/MMU2/src/config.h
+++ b/firmware/MMU2/src/config.h
@@ -54,6 +54,8 @@
 #define CURRENT_HOLDING     {0,  2,  8}
 #define CURRENT_RUNNING     {15, 15, 15}
 
+// Override default RSENSE value
+// #define R_SENSE        0.11f
 
 //number of extruders [1 2 3 4 5]
 #define EXTRUDERS 5

--- a/firmware/MMU2/src/config.h
+++ b/firmware/MMU2/src/config.h
@@ -8,7 +8,11 @@
 //communication uart0/1
 #define UART_COM 1
 
-#define CHOPPER_TIMING  CHOPPER_DEFAULT_12V
+/* Chopper Timing
+*
+* Options: CHOPPER_DEFAULT_12V, CHOPPER_DEFAULT_19V, CHOPPER_DEFAULT_24V
+*/
+#define CHOPPER_TIMING CHOPPER_DEFAULT_24V
 
 /* Print simple drive status information
  * Note that debug mode cannot connect the motherboard normally

--- a/firmware/MMU2/src/config.h
+++ b/firmware/MMU2/src/config.h
@@ -55,7 +55,7 @@
 #define CURRENT_RUNNING     {15, 15, 15}
 
 // Override default RSENSE value
-// #define R_SENSE        0.11f
+// #define R_SENSE        0.11
 
 //number of extruders [1 2 3 4 5]
 #define EXTRUDERS 5

--- a/firmware/MMU2/src/motion.cpp
+++ b/firmware/MMU2/src/motion.cpp
@@ -84,20 +84,20 @@ void motion_set_idler_selector(uint8_t idler, uint8_t selector)
   }
 }
 
-static void check_idler_drive_error()
-{
-  // const uint8_t tries = 2;
-  // for (uint8_t i = 0; i <= tries; ++i)
-  // {
-  //   if (!tmc_read_gstat()) break;
-  //   else
-  //   {
-  //     if (tries == i) unrecoverable_error();
-  //     drive_error();
-  //     rehome_idler();
-  //   }
-  // }
-}
+// static void check_idler_drive_error()
+// {
+//   const uint8_t tries = 2;
+//   for (uint8_t i = 0; i <= tries; ++i)
+//   {
+//     if (!tmc_read_gstat()) break;
+//     else
+//     {
+//       if (tries == i) unrecoverable_error();
+//       drive_error();
+//       rehome_idler();
+//     }
+//   }
+// }
 
 void motion_engage_idler()
 {

--- a/firmware/MMU2/src/trinamic.cpp
+++ b/firmware/MMU2/src/trinamic.cpp
@@ -44,7 +44,7 @@ typedef struct {
   int8_t hend;
 } chopper_timing_t;
 
-static constexpr chopper_timing_t chopper_timing = CHOPPER_DEFAULT_12V;
+static constexpr chopper_timing_t chopper_timing = CHOPPER_TIMING;
 
 #ifdef TMC2208
 TMC2208Stepper pulley(AX_PUL_RX, AX_PUL_TX, R_SENSE);

--- a/firmware/MMU2/src/trinamic.cpp
+++ b/firmware/MMU2/src/trinamic.cpp
@@ -101,6 +101,8 @@ int8_t __sg_thr(AXIS axis)
 	case AX_IDL:
     stallguard=(int8_t)constrain(TMC_SG_THR_IDL,sgt_min, sgt_max);
 	  break;
+  default:
+    break;
 	}
   return stallguard;
 }
@@ -128,6 +130,7 @@ uint8_t tmc_direction(AXIS axis)
     case AX_IDL: return IDLER_DIR_INVERTING; 
     default: break;
   }
+  return 0;
 }
 
 

--- a/firmware/MMU2/src/trinamic.cpp
+++ b/firmware/MMU2/src/trinamic.cpp
@@ -31,8 +31,6 @@
 #include "shr16.h"
 
 
-#define DRIVER_ADDRESS 0b00 // TMC2209 Driver address according to MS1 and MS2
-#define R_SENSE        0.11f // Match to your driver
 #define TMC_BAUD_RATE  19200
 #define current_max    28
 #define current_min    0
@@ -47,23 +45,33 @@ typedef struct {
 static constexpr chopper_timing_t chopper_timing = CHOPPER_TIMING;
 
 #ifdef TMC2208
-TMC2208Stepper pulley(AX_PUL_RX, AX_PUL_TX, R_SENSE);
-TMC2208Stepper selector(AX_SEL_RX, AX_SEL_TX, R_SENSE);
-TMC2208Stepper idler(AX_IDL_RX, AX_IDL_TX, R_SENSE);
-// TMC2208Stepper pulley(AX_PUL_RX, AX_PUL_TX, R_SENSE, DRIVER_ADDRESS);
-// TMC2208Stepper selector(AX_SEL_RX, AX_SEL_TX, R_SENSE, DRIVER_ADDRESS);
-// TMC2208Stepper idler(AX_IDL_RX, AX_IDL_TX, R_SENSE, DRIVER_ADDRESS);
-static uint8_t sgt_min = 0, sgt_max = 255;
+  #ifndef R_SENSE
+    #define R_SENSE 0.11f
+  #endif
+  TMC2208Stepper pulley(AX_PUL_RX, AX_PUL_TX, R_SENSE);
+  TMC2208Stepper selector(AX_SEL_RX, AX_SEL_TX, R_SENSE);
+  TMC2208Stepper idler(AX_IDL_RX, AX_IDL_TX, R_SENSE);
+  // TMC2208Stepper pulley(AX_PUL_RX, AX_PUL_TX, R_SENSE, DRIVER_ADDRESS);
+  // TMC2208Stepper selector(AX_SEL_RX, AX_SEL_TX, R_SENSE, DRIVER_ADDRESS);
+  // TMC2208Stepper idler(AX_IDL_RX, AX_IDL_TX, R_SENSE, DRIVER_ADDRESS);
+  static uint8_t sgt_min = 0, sgt_max = 255;
 #endif
 
 #ifdef TMC2209
-TMC2209Stepper pulley(AX_PUL_RX, AX_PUL_TX, R_SENSE, DRIVER_ADDRESS);
-TMC2209Stepper selector(AX_SEL_RX, AX_SEL_TX, R_SENSE, DRIVER_ADDRESS);
-TMC2209Stepper idler(AX_IDL_RX, AX_IDL_TX, R_SENSE, DRIVER_ADDRESS);
-static uint8_t sgt_min = 0, sgt_max = 255;
+  #define DRIVER_ADDRESS 0b00 // TMC2209 Driver address according to MS1 and MS2
+  #ifndef R_SENSE
+    #define R_SENSE 0.11f
+  #endif
+  TMC2209Stepper pulley(AX_PUL_RX, AX_PUL_TX, R_SENSE, DRIVER_ADDRESS);
+  TMC2209Stepper selector(AX_SEL_RX, AX_SEL_TX, R_SENSE, DRIVER_ADDRESS);
+  TMC2209Stepper idler(AX_IDL_RX, AX_IDL_TX, R_SENSE, DRIVER_ADDRESS);
+  static uint8_t sgt_min = 0, sgt_max = 255;
 #endif
 
 #ifdef TMC2130
+  #ifndef R_SENSE
+    #define R_SENSE 0.11f
+  #endif
   TMC2130Stepper pulley(AX_PUL_CS_PIN, R_SENSE);
   TMC2130Stepper selector(AX_SEL_CS_PIN, R_SENSE);
   TMC2130Stepper idler(AX_IDL_CS_PIN, R_SENSE);   // Hardware SPI
@@ -71,6 +79,9 @@ static uint8_t sgt_min = 0, sgt_max = 255;
 #endif
 
 #ifdef TMC5160
+  #ifndef R_SENSE
+    #define R_SENSE 0.075f
+  #endif
   TMC5160Stepper pulley(AX_PUL_CS_PIN, R_SENSE);
   TMC5160Stepper selector(AX_SEL_CS_PIN, R_SENSE);
   TMC5160Stepper idler(AX_IDL_CS_PIN, R_SENSE); // Hardware SPI

--- a/firmware/MMU2/src/trinamic.cpp
+++ b/firmware/MMU2/src/trinamic.cpp
@@ -46,7 +46,7 @@ static constexpr chopper_timing_t chopper_timing = CHOPPER_TIMING;
 
 #ifdef TMC2208
   #ifndef R_SENSE
-    #define R_SENSE 0.11f
+    #define R_SENSE 0.11
   #endif
   TMC2208Stepper pulley(AX_PUL_RX, AX_PUL_TX, R_SENSE);
   TMC2208Stepper selector(AX_SEL_RX, AX_SEL_TX, R_SENSE);
@@ -60,7 +60,7 @@ static constexpr chopper_timing_t chopper_timing = CHOPPER_TIMING;
 #ifdef TMC2209
   #define DRIVER_ADDRESS 0b00 // TMC2209 Driver address according to MS1 and MS2
   #ifndef R_SENSE
-    #define R_SENSE 0.11f
+    #define R_SENSE 0.11
   #endif
   TMC2209Stepper pulley(AX_PUL_RX, AX_PUL_TX, R_SENSE, DRIVER_ADDRESS);
   TMC2209Stepper selector(AX_SEL_RX, AX_SEL_TX, R_SENSE, DRIVER_ADDRESS);
@@ -70,7 +70,7 @@ static constexpr chopper_timing_t chopper_timing = CHOPPER_TIMING;
 
 #ifdef TMC2130
   #ifndef R_SENSE
-    #define R_SENSE 0.11f
+    #define R_SENSE 0.11
   #endif
   TMC2130Stepper pulley(AX_PUL_CS_PIN, R_SENSE);
   TMC2130Stepper selector(AX_SEL_CS_PIN, R_SENSE);
@@ -80,7 +80,7 @@ static constexpr chopper_timing_t chopper_timing = CHOPPER_TIMING;
 
 #ifdef TMC5160
   #ifndef R_SENSE
-    #define R_SENSE 0.075f
+    #define R_SENSE 0.075
   #endif
   TMC5160Stepper pulley(AX_PUL_CS_PIN, R_SENSE);
   TMC5160Stepper selector(AX_SEL_CS_PIN, R_SENSE);

--- a/firmware/MMU2/src/trinamic.h
+++ b/firmware/MMU2/src/trinamic.h
@@ -72,9 +72,6 @@ inline void pulley_step_pin_reset()    {GPIOB->ODR&=~(1<<4);}
   #define TMC_DRIVE
 #endif
 
-#define DRIVER_ADDRESS 0b00 // TMC2209 Driver address according to MS1 and MS2
-#define R_SENSE       0.11f // Match to your driver
-
 extern uint8_t idler_diag;
 extern uint8_t sel_diag;
 

--- a/firmware/MMU2/src/version.h
+++ b/firmware/MMU2/src/version.h
@@ -3,8 +3,8 @@
 #ifndef VERSION_H_
 #define VERSION_H_
 
-static const uint16_t fw_version = 106; //!< example: 103 means version 1.0.3
-static const uint16_t fw_buildnr = 133; //!< number of commits preceeding current HEAD
+static const uint16_t fw_version = 107; //!< example: 103 means version 1.0.3
+static const uint16_t fw_buildnr = 134; //!< number of commits preceeding current HEAD
 #define FW_HASH "${GIT_COMMIT_HASH}"
 
 //! @macro FW_LOCAL_CHANGES

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -12,6 +12,7 @@
 src_dir      = MMU2
 boards_dir   = buildroot/share/PlatformIO/boards
 default_envs = MMU2_F030C8
+include_dir  = MMU2
 
 [common]
 default_src_filter = +<src/*>


### PR DESCRIPTION
### Description

- Fix chopper timing being set to `CHOPPER_DEFAULT_12V` no matter what you set `CHOPPER_TIMING` to.
- Change default `CHOPPER_TIMING` to `*_24V` since the MK3/S/+ and most printers are 24V these days.
- Allow `R_SENSE` override, add correct RSENSE value for BTT TMC5160s
- Fix some compiler warnings

`*_19V` is available as a `CHOPPER_TIMING` option in the code, but is an unusual voltage. Perhaps it can be dropped?

And I'll ask again since I'm not sure how this works 🙂: When should version/build numbers be bumped?

https://github.com/bigtreetech/MMU2-DIP/blob/e572273be209d6570e306391e8ce6c29f232ae24/firmware/MMU2/src/version.h#L6-L7
